### PR TITLE
Advance string-stream pointer after writing to it.

### DIFF
--- a/src/BipsPl/stream_supp.c
+++ b/src/BipsPl/stream_supp.c
@@ -1964,5 +1964,5 @@ Str_Stream_Putc(CHAR32_T c, StrSInf *str_stream)
       str_stream->ptr = str_stream->buff + size;
     }
 
-  put_wchar(str_stream->ptr, str_stream->buff_alloc_size - 1, c);
+  str_stream->ptr += put_wchar(str_stream->ptr, str_stream->buff_alloc_size - 1, c);
 }


### PR DESCRIPTION
Writing to the string streams is broken. The `ptr` to the beginning of the next write location in the buffer is not advanced. I noticed this when built-ins like `write_atom` and `format_to_atom` always results in an empty atom.